### PR TITLE
Changes from #2729 and #2733

### DIFF
--- a/redbot/cogs/image/image.py
+++ b/redbot/cogs/image/image.py
@@ -223,17 +223,17 @@ class Image(commands.Cog):
     @checks.is_owner()
     @commands.command()
     async def giphycreds(self, ctx):
-        """Explain how to set Giphy API tokens"""
+        """Explain how to set Giphy API tokens."""
 
         message = _(
             "To get a Giphy API Key:\n"
             "1. Login to a Giphy account.\n"
-            "2. Visit [this](https://developers.giphy.com/dashboard) page\n"
-            "3. Press `Create an App`\n"
-            "4. Write an app name, example: `Red Bot`\n"
-            "5. Write an app description, example: `Used for Red Bot`\n"
+            "2. Visit this page https://developers.giphy.com/dashboard.\n"
+            "3. Press *Create an App*.\n"
+            "4. Write an app name, example: *Red Bot*.\n"
+            "5. Write an app description, example: *Used for Red Bot*.\n"
             "6. Copy the API key shown.\n"
-            "7. Do `{prefix}set api GIPHY api_key <your_api_key>`\n"
+            "7. Run the command `{prefix}set api GIPHY api_key <your_api_key_here>`.\n"
         ).format(prefix=ctx.prefix)
 
         await ctx.maybe_send_embed(message)


### PR DESCRIPTION
-Replaced in line code blocks with italics
-Removed []() link formatting (for when embeds are disabled)
-Added a period to the doc string
-Added periods at the end of each line
-"Run the command" instead of "Do" for clarity
-"your_api_key_here" instead of "your_api_key" for consistency